### PR TITLE
Typo fix jokerace-onchain-data.mdx

### DIFF
--- a/docs/pages/technical-how-tos/jokerace-onchain-data.mdx
+++ b/docs/pages/technical-how-tos/jokerace-onchain-data.mdx
@@ -4,7 +4,7 @@
 
 All [JokeRace contracts](https://github.com/jk-labs-inc/jokerace/tree/staging/packages/forge/src) are standardized to version across all chains. To see what version a contract is you just have to call the `version()` function (instructions to do so are [here](/technical-how-tos/verifying-contracts#determine-the-contracts-version)), and that contract version is going to be the same on all chains.
 
-The ABIs and flattend Solidity files for all of the different versions are [here](https://github.com/jk-labs-inc/jokerace/tree/staging/packages/react-app-revamp/contracts/bytecodeAndAbi).
+The ABIs and flattened Solidity files for all of the different versions are [here](https://github.com/jk-labs-inc/jokerace/tree/staging/packages/react-app-revamp/contracts/bytecodeAndAbi).
 
 ## Templates
 - [Social Graph Ventures](https://x.com/socialgraphvc?s=21) made [this overview dashboard](https://dune.com/socialgraphvc/jokerace) of all contests on Zora, Base, Optimism, Arbitrum, and Polygon with various high-level metrics for them, as well as [a parameterizable dashboard for specific contest metrics](https://dune.com/socialgraphvc/jokerace-creator)! These are very helpful templates to start from for querying contest data across multiple chains!


### PR DESCRIPTION
This pull request fixes the typo where "flattend" was used incorrectly in the jokerace-onchain-data.mdx file, changing it to the correct form "flattened."